### PR TITLE
fix: change run_random to np_random for get_number_of_sex_acts

### DIFF
--- a/titan/model.py
+++ b/titan/model.py
@@ -738,7 +738,7 @@ class HIVModel:
 
         # unprotected sex probabilities for primary partnerships
         mean_sex_acts = (
-            agent.get_number_of_sex_acts(self.run_random) * self.calibration.sex.act
+            agent.get_number_of_sex_acts(self.np_random) * self.calibration.sex.act
         )
         total_sex_acts = utils.poisson(mean_sex_acts, self.np_random)
 


### PR DESCRIPTION
distributions are based on numpy's random, not the random module. The current develop branch is not running when using distributions that are not self-defined.