### PR TITLE
Components are reportable class

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,8 +4,8 @@ site_url: http://marshall-lab.github.io/TITAN
 theme:
   name: material
   features:
-    - instant
-    - tabs
+    - navigation.instant
+    - navigation.tabs
 
 plugins:
   - search

--- a/tests/model_test.py
+++ b/tests/model_test.py
@@ -30,7 +30,7 @@ def test_model_init(params):
 
 
 @pytest.mark.unit
-def test_update_AllAgents(make_model, make_agent):
+def test_update_all_agents(make_model, make_agent):
     # make agent 0
     model = make_model()
     assert model.params.agent_zero.interaction_type == "injection"
@@ -47,6 +47,7 @@ def test_update_AllAgents(make_model, make_agent):
     for rel in copy(model.pop.relationships):
         if rel.bond_type in ["Inj", "SexInj"]:
             rel.unbond()
+            model.pop.remove_relationship(rel)
     with pytest.raises(ValueError) as excinfo:
         model.update_all_agents()
     assert "No agent zero!" in str(excinfo)

--- a/tests/output_test.py
+++ b/tests/output_test.py
@@ -30,41 +30,43 @@ def stats(params, world_location):
     a.high_risk.time = cur_time
     a.incar.active = True
     a.incar.release_time = cur_time
+    a.component = 0
 
     agent_set = agent.AgentSet("test")
     agent_set.add_agent(a)
     agent_list = [a]
     feat_list = [feature for feature in features.BaseFeature.__subclasses__()]
     expose_list = [exposure for exposure in exposures.BaseExposure.__subclasses__()]
+    params.classes.components = ["-1", "0"]
     stats = get_stats(agent_set, agent_list, params, feat_list, expose_list, cur_time)
     return stats
 
 
 @pytest.mark.unit
 def test_get_stats(stats):
-    assert stats["world"]["black"]["MSM"]["agents"] == 1
-    assert stats["world"]["white"]["MSM"]["agents"] == 0
-    assert stats["world"]["black"]["MSM"]["incar"] == 1
-    assert stats["world"]["black"]["MSM"]["incar_hiv"] == 1
-    assert stats["world"]["black"]["MSM"]["new_release"] == 1
-    assert stats["world"]["black"]["MSM"]["new_release_hiv"] == 1
-    assert stats["world"]["black"]["MSM"]["hiv_new"] == 1
-    assert stats["world"]["black"]["MSM"]["hiv_new_high_risk_ever"] == 1
-    assert stats["world"]["black"]["MSM"]["hiv_new_high_risk"] == 1
-    assert stats["world"]["black"]["MSM"]["prep"] == 1
-    assert stats["world"]["black"]["MSM"]["prep_new"] == 1
-    assert stats["world"]["black"]["MSM"]["hiv_dx_new"] == 1
-    assert stats["world"]["black"]["MSM"]["high_risk_new"] == 1
-    assert stats["world"]["black"]["MSM"]["high_risk_new_hiv"] == 1
-    assert stats["world"]["black"]["MSM"]["high_risk_new_aids"] == 1
-    assert stats["world"]["black"]["MSM"]["high_risk_new_dx"] == 1
-    assert stats["world"]["black"]["MSM"]["high_risk_new_haart"] == 1
-    assert stats["world"]["black"]["MSM"]["hiv"] == 1
-    assert stats["world"]["black"]["MSM"]["hiv_aids"] == 1
-    assert stats["world"]["black"]["MSM"]["hiv_dx"] == 1
-    assert stats["world"]["black"]["MSM"]["haart"] == 1
-    assert stats["world"]["black"]["MSM"]["deaths"] == 1
-    assert stats["world"]["black"]["MSM"]["deaths_hiv"] == 1
+    assert stats["world"]["black"]["MSM"]["0"]["Inj"]["agents"] == 1
+    assert stats["world"]["white"]["MSM"]["0"]["Inj"]["agents"] == 0
+    assert stats["world"]["black"]["MSM"]["0"]["Inj"]["incar"] == 1
+    assert stats["world"]["black"]["MSM"]["0"]["Inj"]["incar_hiv"] == 1
+    assert stats["world"]["black"]["MSM"]["0"]["Inj"]["new_release"] == 1
+    assert stats["world"]["black"]["MSM"]["0"]["Inj"]["new_release_hiv"] == 1
+    assert stats["world"]["black"]["MSM"]["0"]["Inj"]["hiv_new"] == 1
+    assert stats["world"]["black"]["MSM"]["0"]["Inj"]["hiv_new_high_risk_ever"] == 1
+    assert stats["world"]["black"]["MSM"]["0"]["Inj"]["hiv_new_high_risk"] == 1
+    assert stats["world"]["black"]["MSM"]["0"]["Inj"]["prep"] == 1
+    assert stats["world"]["black"]["MSM"]["0"]["Inj"]["prep_new"] == 1
+    assert stats["world"]["black"]["MSM"]["0"]["Inj"]["hiv_dx_new"] == 1
+    assert stats["world"]["black"]["MSM"]["0"]["Inj"]["high_risk_new"] == 1
+    assert stats["world"]["black"]["MSM"]["0"]["Inj"]["high_risk_new_hiv"] == 1
+    assert stats["world"]["black"]["MSM"]["0"]["Inj"]["high_risk_new_aids"] == 1
+    assert stats["world"]["black"]["MSM"]["0"]["Inj"]["high_risk_new_dx"] == 1
+    assert stats["world"]["black"]["MSM"]["0"]["Inj"]["high_risk_new_haart"] == 1
+    assert stats["world"]["black"]["MSM"]["0"]["Inj"]["hiv"] == 1
+    assert stats["world"]["black"]["MSM"]["0"]["Inj"]["hiv_aids"] == 1
+    assert stats["world"]["black"]["MSM"]["0"]["Inj"]["hiv_dx"] == 1
+    assert stats["world"]["black"]["MSM"]["0"]["Inj"]["haart"] == 1
+    assert stats["world"]["black"]["MSM"]["0"]["Inj"]["deaths"] == 1
+    assert stats["world"]["black"]["MSM"]["0"]["Inj"]["deaths_hiv"] == 1
 
 
 @pytest.mark.unit
@@ -81,7 +83,12 @@ def test_basicReport(stats, params, tmpdir):
             assert row["t"] == "0"
             assert row["run_id"] == str(run_id)
             assert row["rseed"] == "1"
-            if row["race"] == "black" and row["sex_type"] == "MSM":
+            if (
+                row["race"] == "black"
+                and row["sex_type"] == "MSM"
+                and row["component"] == "0"
+                and row["drug_type"] == "Inj"
+            ):
                 assert row["agents"] == "1"
                 assert row["hiv"] == "1"
                 assert row["prep"] == "1"
@@ -100,7 +107,7 @@ def test_print_components(stats, params, make_population, tmpdir):
     pop = make_population(n=1)
     components = pop.connected_components()
 
-    print_components(run_id, 0, 1, 2, components, tmpdir, params.classes.races)
+    print_components(run_id, 0, 1, 2, components, tmpdir)
 
     result_file = os.path.join(tmpdir, f"{run_id}_componentReport_ALL.txt")
     assert os.path.isfile(result_file)
@@ -110,8 +117,7 @@ def test_print_components(stats, params, make_population, tmpdir):
             assert row["t"] == "0"
             assert row["run_id"] == str(run_id)
             assert row["runseed"] == "1"
-            assert row["compID"] == "0"
-            assert row["totalN"] == "1"
+            assert row["component"] == "0"
 
 
 @pytest.mark.unit

--- a/tests/params/basic.yml
+++ b/tests/params/basic.yml
@@ -234,7 +234,7 @@ partnership:
         receptive: 0.0138
         versatile: 0.00745
   duration:
-    Sex: 
+    Sex:
       white:
         type: bins
         bins:
@@ -308,6 +308,8 @@ outputs:
     - locations
     - races
     - sex_types
+    - components
+    - drug_types
 
 exposures:
   hiv: true

--- a/titan/agent.py
+++ b/titan/agent.py
@@ -55,6 +55,7 @@ class Agent:
         self.race = race
         self.drug_type = drug_use
         self.location = location
+        self.component = "-1"  # updated after relationships created
 
         self.sex_role = "versatile"
 

--- a/titan/features/random_trial.py
+++ b/titan/features/random_trial.py
@@ -21,7 +21,7 @@ class RandomTrial(base_feature.BaseFeature):
 
         * random_trial - number of agents with active random_trial
         * random_trial_treated - number of active agents treated
-        * random_trial_treated_hiv - number of HIV+ agents treated 
+        * random_trial_treated_hiv - number of HIV+ agents treated
         * random_trial_suitable - number of active agents suitable
     """
 

--- a/titan/features/random_trial.py
+++ b/titan/features/random_trial.py
@@ -10,7 +10,12 @@ import networkx as nx  # type: ignore
 class RandomTrial(base_feature.BaseFeature):
 
     name = "random_trial"
-    stats = ["random_trial", "random_trial_treated", "random_trial_suitable", "random_trial_treated_hiv"]
+    stats = [
+        "random_trial",
+        "random_trial_treated",
+        "random_trial_suitable",
+        "random_trial_treated_hiv",
+    ]
     """
         Random Trial collects the following stats:
 
@@ -154,7 +159,7 @@ class RandomTrial(base_feature.BaseFeature):
             stats["random_trial"] += 1
             if self.treated:
                 stats["random_trial_treated"] += 1
-                if self.agent.hiv.active: # type: ignore[attr-defined]
+                if self.agent.hiv.active:  # type: ignore[attr-defined]
                     stats["random_trial_treated_hiv"] += 1
             if self.suitable:
                 stats["random_trial_suitable"] += 1

--- a/titan/params/outputs.yml
+++ b/titan/params/outputs.yml
@@ -35,3 +35,4 @@ outputs:
       - sex_types
       - drug_types
       - locations
+      - components

--- a/titan/population.py
+++ b/titan/population.py
@@ -405,6 +405,8 @@ class Population:
                     ):
                         eligible_agents.append(agent)
 
+        self.update_agent_components()
+
     def update_partner_targets(self):
         """
         Update the target number of partners for each agent and bond type
@@ -430,6 +432,18 @@ class Population:
                 a.target_partners[bond] * self.params.calibration.partnership.buffer
             ):
                 self.partnerable_agents[bond].add(a)
+
+    def update_agent_components(self):
+        """
+        Update the component IDs associated with each agent based on the current state of the graph
+        """
+        if self.enable_graph:
+            components = self.connected_components()
+            for id, component in enumerate(self.connected_components()):
+                for agent in component.nodes:
+                    agent.component = str(id)
+
+            self.params.classes.components = list(map(str, range(len(components))))
 
     def trim_graph(self):
         """
@@ -462,7 +476,7 @@ class Population:
                     if sub_comp.number_of_nodes() > max_size:
                         trim_component(component, max_size)
 
-            components = sorted(self.connected_components(), key=len, reverse=True)
+            components = self.connected_components()
             for comp in components:
                 if (
                     comp.number_of_nodes()
@@ -481,7 +495,7 @@ class Population:
             list of connected components
         """
         if self.enable_graph:
-            return utils.connected_components(self.graph)
+            return sorted(utils.connected_components(self.graph), key=len, reverse=True)
         else:
             raise ValueError(
                 "Can't get connected_components, population doesn't have graph enabled."

--- a/titan/population_io.py
+++ b/titan/population_io.py
@@ -190,6 +190,8 @@ def read(params: ObjMap, path: str) -> Population:
             r = create_relationship(row, pop)
             pop.add_relationship(r)
 
+    pop.update_agent_components()
+
     return pop
 
 

--- a/titan/run_titan.py
+++ b/titan/run_titan.py
@@ -321,7 +321,7 @@ def setup_outdir(outdir, save_pop):
     return outfile_dir
 
 
-def get_sweep_defs(sweepfile, rows, sweeps, num_reps):
+def get_sweep_defs(sweepfile, rows, sweeps, num_reps, force):
     """
     Get the sweep definitions from file if available, then from the command line definitions, otherwise return an empty definition to ensure the model runs.
     """
@@ -385,7 +385,7 @@ def main(
     )
 
     # set up sweeps
-    sweep_defs = get_sweep_defs(sweepfile, rows, sweeps, num_reps)
+    sweep_defs = get_sweep_defs(sweepfile, rows, sweeps, num_reps, force)
 
     tic = time_mod.time()
     wct = []  # wall clock times


### PR DESCRIPTION
* assign all agents a component id
* update the ID after each round of partnering updates
* update the `params.classes.components` with the range of IDs after each round of partnering updates
* add components to classes that can be reported on
* remove most (all) demographic reporting from the component report
* re-order `update_all_agents` so the components during interaction are the components active at the time of reporting