### PR TITLE
Feat logging

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -113,8 +113,14 @@ jobs:
       run: poetry install
     - name: Integration Test with pytest
       run: poetry run pytest -m integration_stochastic --cov=titan --cov-report=xml
+    - name: Re-run integration tests if failed
+      if: ${{ failure() }}
+      run: poetry run pytest -m integration_stochastic --cov=titan --cov-report=xml
+    - name: Re-run integration tests if failed (x2)
+      if: ${{ failure() }}
+      run: poetry run pytest -m integration_stochastic --cov=titan --cov-report=xml
     - name: Upload coverage to Codecov
-      if: always()
+      if: ${{ always() }}
       uses: codecov/codecov-action@v1
       with:
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -112,8 +112,10 @@ jobs:
     - name: Install dependencies
       run: poetry install
     - name: Integration Test with pytest
+      continue-on-error: true
       run: poetry run pytest -m integration_stochastic --cov=titan --cov-report=xml
     - name: Re-run integration tests if failed
+      continue-on-error: true
       if: ${{ failure() }}
       run: poetry run pytest -m integration_stochastic --cov=titan --cov-report=xml
     - name: Re-run integration tests if failed (x2)

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ ipynb/.ipynb_checkpoints/
 results/
 results/*.txt
 results/*/*.txt
+*log*.txt
 
 profile.prof
 site/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "titan-model"
-version = "2.4.0"
+version = "2.5.0"
 description = "TITAN Agent Based Model"
 license = "GPL-3.0-only"
 authors = ["Sam Bessey <sam_bessey@brown.edu>", "Mary McGrath <mary_mcgrath@brown.edu>"]

--- a/tests/params/basic.yml
+++ b/tests/params/basic.yml
@@ -310,8 +310,8 @@ outputs:
     - sex_types
     - components
     - drug_types
-  # logging:
-  #   to_file: true
+  logging:
+    to_file: true
 
 exposures:
   hiv: true

--- a/tests/params/basic.yml
+++ b/tests/params/basic.yml
@@ -310,6 +310,8 @@ outputs:
     - sex_types
     - components
     - drug_types
+  # logging:
+  #   to_file: true
 
 exposures:
   hiv: true

--- a/tests/params/basic.yml
+++ b/tests/params/basic.yml
@@ -310,8 +310,6 @@ outputs:
     - sex_types
     - components
     - drug_types
-  logging:
-    to_file: true
 
 exposures:
   hiv: true

--- a/tests/population_io_test.py
+++ b/tests/population_io_test.py
@@ -60,7 +60,7 @@ def test_write_pop(tmpdir, make_population):
             assert repr(getattr(r, attr)) == row[attr]
 
 
-@pytest.mark.unit
+@pytest.mark.broken
 def test_read_pop(tmpdir, make_population, params):
     pop = make_population(n=10)
     prep_counts = deepcopy(Prep.counts)
@@ -82,6 +82,7 @@ def test_read_pop(tmpdir, make_population, params):
     for attr in attrs:
         orig_attr = getattr(agent, attr)
         new_attr = getattr(new_agent, attr)
+        print(attr)
         if isinstance(orig_attr, BaseFeature):
             feat_attrs = orig_attr.__dict__.keys()
             for feat_attr in feat_attrs:

--- a/tests/population_io_test.py
+++ b/tests/population_io_test.py
@@ -60,7 +60,7 @@ def test_write_pop(tmpdir, make_population):
             assert repr(getattr(r, attr)) == row[attr]
 
 
-@pytest.mark.broken
+@pytest.mark.unit
 def test_read_pop(tmpdir, make_population, params):
     pop = make_population(n=10)
     prep_counts = deepcopy(Prep.counts)

--- a/titan/agent.py
+++ b/titan/agent.py
@@ -88,8 +88,8 @@ class Agent:
             String formatted tab-deliminated agent properties
         """
         return (
-            f"\t{self.id}\t{self.age}\t{self.sex_type}\t{self.drug_type}\t"  # type: ignore[attr-defined]
-            f"{self.race}\t{self.hiv.active}"
+            f"\t{self.id}\t{self.age}\t{self.sex_type}\t{self.drug_type}\t"
+            f"{self.race}\t{self.hiv.active}"  # type: ignore[attr-defined]
         )
 
     def __repr__(self) -> str:

--- a/titan/agent.py
+++ b/titan/agent.py
@@ -88,7 +88,7 @@ class Agent:
             String formatted tab-deliminated agent properties
         """
         return (
-            f"\t{self.id}\t{self.age}\t{self.sex_type}\t{self.drug_type}\t"
+            f"\t{self.id}\t{self.age}\t{self.sex_type}\t{self.drug_type}\t"  # type: ignore[attr-defined]
             f"{self.race}\t{self.hiv.active}"  # type: ignore[attr-defined]
         )
 

--- a/titan/agent.py
+++ b/titan/agent.py
@@ -460,14 +460,16 @@ class AgentSet:
         for subset in list(self.subset.values()):
             yield subset
 
-    def print_subsets(self):
+    def print_subsets(self, printer=print):
         """
         Pretty print the subsets of this agent set
         """
-        print(f"\t__________ {self.id} __________")
-        print("\tID\t\tN\t\t%")
+        lines = []
+
+        lines.append(f"\t__________ {self.id} __________")
+        lines.append("\tID\t\tN\t\t%")
         for set in self.iter_subset():
-            print(
+            lines.append(
                 "\t{:6}\t\t{:5}\t\t{:.2}".format(
                     set.id,
                     set.num_members(),
@@ -475,7 +477,7 @@ class AgentSet:
                 )
             )
             for subset in set.iter_subset():
-                print(
+                lines.append(
                     "\t{:4}\t\t{:5}\t\t{:.2}".format(
                         subset.id,
                         subset.num_members(),
@@ -484,4 +486,5 @@ class AgentSet:
                         ),
                     )
                 )
-        print("\t______________ END ______________")
+        lines.append("\t______________ END ______________")
+        printer("\n".join(lines))

--- a/titan/agent.py
+++ b/titan/agent.py
@@ -467,10 +467,11 @@ class AgentSet:
         lines = []
 
         lines.append(f"\t__________ {self.id} __________")
-        lines.append("\tID\t\tN\t\t%")
+        # lines.append("\tID\t\tN\t\t%")
+        lines.append("\t{:^6}\t\t{:^5}\t\t{:^4}".format("ID", "N", "%"))
         for set in self.iter_subset():
             lines.append(
-                "\t{:6}\t\t{:5}\t\t{:.2}".format(
+                "\t{:^6}\t\t{:^5}\t\t{:.2}".format(
                     set.id,
                     set.num_members(),
                     safe_divide(set.num_members(), set.parent_set.num_members()),

--- a/titan/features/random_trial.py
+++ b/titan/features/random_trial.py
@@ -1,4 +1,5 @@
 from typing import Dict
+import logging
 
 from . import base_feature
 from .. import utils
@@ -51,7 +52,7 @@ class RandomTrial(base_feature.BaseFeature):
             model.params.model.network.enable
         ), "Network must be enabled for random trial"
 
-        print(f"Starting random trial ({rt_params.choice})")
+        logging.info(f"Starting random trial ({rt_params.choice})")
         components = model.pop.connected_components()
 
         # set up helper methods based on params
@@ -69,9 +70,8 @@ class RandomTrial(base_feature.BaseFeature):
             suitable = suitable_knowledge
 
         total_nodes = 0
-        print(
-            "Number of components",
-            len([1 for comp in components if comp.number_of_nodes()]),
+        logging.info(
+            f"Number of components {len([1 for comp in components if comp.number_of_nodes()])}",
         )
         for comp in components:
             total_nodes += comp.number_of_nodes()
@@ -152,7 +152,7 @@ class RandomTrial(base_feature.BaseFeature):
                     chosen_agent.random_trial.treated = True  # type: ignore[attr-defined]
                     treat(chosen_agent, model)
 
-        print(("Total agents in trial: ", total_nodes))
+        logging.info(f"Total agents in trial: {total_nodes}")
 
     def set_stats(self, stats: Dict[str, int], time: int):
         if self.active:

--- a/titan/features/syringe_services.py
+++ b/titan/features/syringe_services.py
@@ -1,3 +1,5 @@
+import logging
+
 from . import base_feature
 from .. import model as hiv_model
 from .. import utils
@@ -34,7 +36,7 @@ class SyringeServices(base_feature.BaseFeature):
         args:
             model: the instance of TITAN currently being run
         """
-        print(("\n\n!!!!Engaging syringe services program"))
+        logging.info(("\n\n!!!!Engaging syringe services program"))
         ssp_num_slots = 0
         ssp_agents = {
             agent for agent in model.pop.pwid_agents if agent.syringe_services.active  # type: ignore[attr-defined]
@@ -82,7 +84,7 @@ class SyringeServices(base_feature.BaseFeature):
             else:
                 break
 
-        print(
+        logging.info(
             f"SSP has {ssp_num_slots} target slots with "
             f"{len(ssp_agents)} slots filled"
         )

--- a/titan/model.py
+++ b/titan/model.py
@@ -47,10 +47,10 @@ class TITAN:
         logging.info("=== Begin Initialization Protocol ===\n")
 
         if pop is None:
-            logging.info("\tGenerating new population")
+            logging.info("  Generating new population")
             self.pop = population.Population(params)
         else:
-            logging.info("\tUsing provided population")
+            logging.info("  Using provided population")
             self.pop = pop
 
         self.time = -1 * self.params.model.time.burn_steps  # burn is negative time
@@ -75,13 +75,13 @@ class TITAN:
 
         # Set seed format. 0: pure random, else: fixed value
         self.run_seed = utils.get_check_rand_int(params.model.seed.run)
-        logging.info(f"\tRun seed was set to: {self.run_seed}")
+        logging.info(f"  Run seed was set to: {self.run_seed}")
         self.run_random = random.Random(self.run_seed)
         self.np_random = np.random.default_rng(self.run_seed)
         random.seed(self.run_seed)
-        logging.info(("\tFIRST RANDOM CALL {}".format(random.randint(0, 100))))
+        logging.info(("  FIRST RANDOM CALL {}".format(random.randint(0, 100))))
 
-        logging.info("\tResetting death count")
+        logging.info("  Resetting death count")
         self.deaths: List["ag.Agent"] = []  # Number of death
 
         logging.info("\n=== Initialization Protocol Finished ===")
@@ -154,20 +154,20 @@ class TITAN:
         self.print_stats(stats, outdir)
 
         if self.params.model.time.burn_steps > 0:
-            logging.info("\t===! Start Burn Loop !===")
+            logging.info("  ===! Start Burn Loop !===")
 
         # time starts at negative burn steps, model run starts at t = 1
         while self.time < self.params.model.time.num_steps:
             if self.time == 0:
                 if self.params.model.time.burn_steps > 0:
-                    logging.info("\t===! Burn Loop Complete !===")
-                logging.info("\t===! Start Main Loop !===")
+                    logging.info("  ===! Burn Loop Complete !===")
+                logging.info("  ===! Start Main Loop !===")
 
             self.time += 1
             self.step(outdir)
             self.reset_trackers()
 
-        logging.info("\t===! Main Loop Complete !===")
+        logging.info("  ===! Main Loop Complete !===")
 
     def step(self, outdir: str):
         """
@@ -180,9 +180,11 @@ class TITAN:
         args:
             outdir: path to directory where reports should be saved
         """
-        logging.info(f"\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t.: TIME {self.time}")
         logging.info(
-            "\tSTARTING HIV count:{}\tTotal Incarcerated:{}\tHR+:{}\t"
+            f"\n                                                  .: TIME {self.time}"
+        )
+        logging.info(
+            "  STARTING HIV count:{}  Total Incarcerated:{}  HR+:{}  "
             "PrEP:{}".format(
                 len(exposures.HIV.agents),
                 sum([1 for a in self.pop.all_agents if a.incar.active]),  # type: ignore[attr-defined]

--- a/titan/params/outputs.yml
+++ b/titan/params/outputs.yml
@@ -46,7 +46,7 @@ outputs:
         - file
     filepath:
       default: '__cwd__'
-      description: The directory path wherethe logs will be printed to if `destination` is `file`.  The logs will be named `titan_log_<date/time>.txt`.  The default is your current working directory.
+      description: The directory path where the logs will be printed to if `destination` is `file`.  The logs will be named `titan_log_<date/time>.txt`.  The default is your current working directory.
       type: any
     level:
       default: 'INFO'

--- a/titan/params/outputs.yml
+++ b/titan/params/outputs.yml
@@ -37,18 +37,21 @@ outputs:
       - locations
       - components
   logging:
-    to_file:
-      default: false
-      type: boolean
-      description: Whether to log to a file instead of the console (default)
+    destination:
+      default: stdout
+      type: enum
+      description: Whether to log to a file or the console (default)
+      values:
+        - stdout
+        - file
     filepath:
       default: '__cwd__'
-      description: The directory path wherethe logs will be printed to if `to_file` is true.  The logs will be named `titan_<run id>_log.txt`.  The default is your current working directory.
+      description: The directory path wherethe logs will be printed to if `destination` is `file`.  The logs will be named `titan_log_<date/time>.txt`.  The default is your current working directory.
       type: any
     level:
       default: 'INFO'
       type: enum
-      description: What is the minimum log level to record?
+      description: What is the minimum log level to record? See https://docs.python.org/3/howto/logging.html#when-to-use-logging for details on what the levels mean.
       values:
         - 'DEBUG'
         - 'INFO'

--- a/titan/params/outputs.yml
+++ b/titan/params/outputs.yml
@@ -36,3 +36,21 @@ outputs:
       - drug_types
       - locations
       - components
+  logging:
+    to_file:
+      default: false
+      type: boolean
+      description: Whether to log to a file instead of the console (default)
+    filepath:
+      default: '__cwd__'
+      description: The directory path wherethe logs will be printed to if `to_file` is true.  The logs will be named `titan_<run id>_log.txt`.  The default is your current working directory.
+      type: any
+    level:
+      default: 'INFO'
+      type: enum
+      description: What is the minimum log level to record?
+      values:
+        - 'DEBUG'
+        - 'INFO'
+        - 'WARNING'
+        - 'ERROR'

--- a/titan/parse_params.py
+++ b/titan/parse_params.py
@@ -23,7 +23,7 @@ class ObjMap(dict):
     def __getattribute__(self, k):
         try:
             return self[k]
-        except:
+        except KeyError:
             return object.__getattribute__(self, k)
 
     def __setattr__(self, k, v):

--- a/titan/population.py
+++ b/titan/population.py
@@ -101,7 +101,7 @@ class Population:
             self.params
         )
 
-        logging.info("\tCreating agents")
+        logging.info("  Creating agents")
         # for each location in the population, create agents per that location's demographics
         init_time = -1 * self.params.model.time.burn_steps
         for loc in self.geography.locations.values():
@@ -122,7 +122,7 @@ class Population:
                     self.add_agent(agent)
 
         # initialize relationships
-        logging.info("\tCreating Relationships")
+        logging.info("  Creating Relationships")
         self.update_partner_assignments(0)
 
     def create_agent(
@@ -494,7 +494,7 @@ class Population:
                     logging.info("TOO BIG", comp, comp.number_of_nodes())
                     trim_component(comp, self.params.model.network.component_size.max)
 
-        logging.info(f"\tTotal agents in graph: {self.graph.number_of_nodes()}")
+        logging.info(f"  Total agents in graph: {self.graph.number_of_nodes()}")
 
     def connected_components(self) -> List:
         """

--- a/titan/population.py
+++ b/titan/population.py
@@ -6,6 +6,7 @@ from collections import deque
 from copy import copy
 from math import ceil
 from typing import List, Dict, Set, Optional, Tuple
+import logging
 
 import numpy as np  # type: ignore
 import networkx as nx  # type: ignore
@@ -33,6 +34,10 @@ class Population:
             self.id = nanoid.generate(size=8)
         else:
             self.id = id
+
+        utils.set_up_logging(params)
+
+        logging.info(f"Population ID: {self.id}")
 
         self.pop_seed = utils.get_check_rand_int(params.model.seed.ppl)
 
@@ -96,7 +101,7 @@ class Population:
             self.params
         )
 
-        print("\tCreating agents")
+        logging.info("\tCreating agents")
         # for each location in the population, create agents per that location's demographics
         init_time = -1 * self.params.model.time.burn_steps
         for loc in self.geography.locations.values():
@@ -109,7 +114,7 @@ class Population:
                     )
                 ):
                     if self.all_agents.num_members() >= self.params.model.num_pop:
-                        print(
+                        logging.warning(
                             "WARNING: not adding agent to population - too many agents"
                         )
                         break
@@ -117,7 +122,7 @@ class Population:
                     self.add_agent(agent)
 
         # initialize relationships
-        print("\tCreating Relationships")
+        logging.info("\tCreating Relationships")
         self.update_partner_assignments(0)
 
     def create_agent(
@@ -486,10 +491,10 @@ class Population:
                     comp.number_of_nodes()
                     > self.params.model.network.component_size.max
                 ):
-                    print("TOO BIG", comp, comp.number_of_nodes())
+                    logging.info("TOO BIG", comp, comp.number_of_nodes())
                     trim_component(comp, self.params.model.network.component_size.max)
 
-        print("\tTotal agents in graph: ", self.graph.number_of_nodes())
+        logging.info(f"\tTotal agents in graph: {self.graph.number_of_nodes()}")
 
     def connected_components(self) -> List:
         """

--- a/titan/population_io.py
+++ b/titan/population_io.py
@@ -5,6 +5,7 @@ from shutil import make_archive, unpack_archive
 from tempfile import mkdtemp
 import glob
 import re
+import logging
 
 from .population import Population
 from .agent import Agent, Relationship
@@ -12,6 +13,7 @@ from .parse_params import ObjMap
 from .location import Location
 from . import features
 from . import exposures
+from . import utils
 
 agent_feature_attrs = [
     feature.name for feature in features.BaseFeature.__subclasses__()
@@ -39,6 +41,8 @@ def write(pop: Population, dir: str, compress: bool = True) -> str:
         path, or archive name if compress is true
     """
     assert len(pop.relationships) > 0, "Can't write empty population"
+
+    utils.set_up_logging(pop.params)
 
     # open agent file
     agent_file = os.path.join(dir, f"{pop.id}_agents.csv")
@@ -86,7 +90,7 @@ def write(pop: Population, dir: str, compress: bool = True) -> str:
 
 
 def write_extra_class_file(file_name, collection, extra, attrs):
-    print(f"Creating {file_name}")
+    logging.info(f"Creating {file_name}")
     with open(file_name, "w", newline="") as f:
         writer = csv.DictWriter(f, fieldnames=attrs)
         writer.writeheader()
@@ -96,7 +100,7 @@ def write_extra_class_file(file_name, collection, extra, attrs):
 
 
 def write_class_file(file_name, collection, attrs):
-    print(f"Creating {file_name}")
+    logging.info(f"Creating {file_name}")
     with open(file_name, "w", newline="") as f:
         writer = csv.DictWriter(f, fieldnames=attrs)
         writer.writeheader()

--- a/titan/run_titan.py
+++ b/titan/run_titan.py
@@ -10,6 +10,7 @@ from multiprocessing import Pool, cpu_count
 import csv
 import traceback
 from typing import List, Optional
+import logging
 
 # allow imports to work if running it as a script for development locally
 if __name__ == "__main__":

--- a/titan/run_titan.py
+++ b/titan/run_titan.py
@@ -258,6 +258,8 @@ def single_run(sweep, outfile_dir, params, save_pop, pop_path):
     """
     A single run of titan.  Dispatched from main using parallel processes.
     """
+    utils.set_up_logging(params)
+
     pid = str(os.getpid())
     pid_outfile_dir = os.path.join(outfile_dir, pid)
     save_pop_dir = (
@@ -285,7 +287,7 @@ def single_run(sweep, outfile_dir, params, save_pop, pop_path):
 
     if save_pop_dir is not None:
         pop_io.write(pop, save_pop_dir)
-        print(f"Population saved to: {save_pop_dir}")
+        logging.info(f"Population saved to: {save_pop_dir}")
 
     try:
         model = TITAN(params, pop=pop)

--- a/titan/utils.py
+++ b/titan/utils.py
@@ -307,14 +307,20 @@ def get_cumulative_bin(rand_gen, bin_def: ObjMap) -> int:
 
     return bin
 
+
 def set_up_logging(params):
     # set up logging
     if params.outputs.logging.to_file:
-        log_msg_format = "[%(asctime)s][%(levelname)s][%(module)s]\n\t%(message)s"
+        log_msg_format = "{message:<60}\t[{asctime}][{levelname}][{module}]"
         log_dt_format = "%Y%m%d%H%M%S"
-        path = os.getcwd() if params.outputs.logging.filepath == '__cwd__' else params.outputs.logging.filepath
+        path = (
+            os.getcwd()
+            if params.outputs.logging.filepath == "__cwd__"
+            else params.outputs.logging.filepath
+        )
         logging.basicConfig(
             format=log_msg_format,
+            style="{",
             datefmt=log_dt_format,
             filename=os.path.join(
                 path, f"titan_log_{datetime.now().strftime(log_dt_format)}.txt"

--- a/titan/utils.py
+++ b/titan/utils.py
@@ -310,7 +310,7 @@ def get_cumulative_bin(rand_gen, bin_def: ObjMap) -> int:
 
 def set_up_logging(params):
     # set up logging
-    if params.outputs.logging.to_file:
+    if params.outputs.logging.destination == "file":
         log_msg_format = "{message:<64}  [{asctime}][{levelname}][{module}]"
         log_dt_format = "%Y%m%d%H%M%S"
         path = (

--- a/titan/utils.py
+++ b/titan/utils.py
@@ -311,7 +311,7 @@ def get_cumulative_bin(rand_gen, bin_def: ObjMap) -> int:
 def set_up_logging(params):
     # set up logging
     if params.outputs.logging.to_file:
-        log_msg_format = "{message:<60}\t[{asctime}][{levelname}][{module}]"
+        log_msg_format = "{message:<64}  [{asctime}][{levelname}][{module}]"
         log_dt_format = "%Y%m%d%H%M%S"
         path = (
             os.getcwd()

--- a/titan/utils.py
+++ b/titan/utils.py
@@ -2,6 +2,9 @@ import random
 from functools import wraps
 from typing import TypeVar, Collection, Union, Iterable
 from math import floor
+import logging
+import os
+from datetime import datetime
 
 import networkx as nx  # type: ignore
 
@@ -209,7 +212,7 @@ def scale_param(params: ObjMap, param_path: str, scalar: float, delimiter="|"):
     scaling_item, last_key = get_param_from_path(params, param_path, delimiter)
 
     old_val = scaling_item[last_key]
-    print(f"scaling - {param_path}: {old_val} => {old_val * scalar}")
+    logging.info(f"scaling - {param_path}: {old_val} => {old_val * scalar}")
     scaling_item[last_key] = old_val * scalar
 
 
@@ -225,7 +228,7 @@ def override_param(params: ObjMap, param_path: str, value, delimiter="|"):
         last_key = int(last_key)
         old_val = override_item[last_key]
 
-    print(f"overriding - {param_path}: {old_val} => {value}")
+    logging.info(f"overriding - {param_path}: {old_val} => {value}")
     override_item[last_key] = value
 
 
@@ -303,3 +306,24 @@ def get_cumulative_bin(rand_gen, bin_def: ObjMap) -> int:
             break
 
     return bin
+
+def set_up_logging(params):
+    # set up logging
+    if params.outputs.logging.to_file:
+        log_msg_format = "[%(asctime)s][%(levelname)s][%(module)s]\n\t%(message)s"
+        log_dt_format = "%Y%m%d%H%M%S"
+        path = os.getcwd() if params.outputs.logging.filepath == '__cwd__' else params.outputs.logging.filepath
+        logging.basicConfig(
+            format=log_msg_format,
+            datefmt=log_dt_format,
+            filename=os.path.join(
+                path, f"titan_log_{datetime.now().strftime(log_dt_format)}.txt"
+            ),
+            level=params.outputs.logging.level,
+        )
+    else:
+        log_msg_format = "%(message)s"
+        logging.basicConfig(
+            format=log_msg_format,
+            level=params.outputs.logging.level,
+        )


### PR DESCRIPTION
<!-- remember to bump the version in pyproject.toml as appropriate! -->

* Use `logging` functionality instead of prints
* Default is still to print to stdout
* Added `logging` params section to `outputs` params, which can instead send the logs to file (timestamped) or set a different log level (though currently most logs are `INFO`)
* Retry stochastic integration tests a few times before declaring failure