### PR TITLE
test: ignore philly on stable pop

### DIFF
--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -178,7 +178,9 @@ def test_agent_pop_stable_setting(tmpdir):
             os.path.dirname(os.path.abspath(__file__)), "..", "titan", "settings"
         )
     ):
-        if "__" not in item and item != "base" and item != "philly-gis":  # bypass philly due to constraints
+        if (
+            "__" not in item and item != "base" and item != "philly-gis"
+        ):  # bypass philly due to constraints
             path = tmpdir.mkdir(item)
             os.mkdir(os.path.join(path, "network"))
             print(f"-----------Starting run for {item}-----------")

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -178,7 +178,7 @@ def test_agent_pop_stable_setting(tmpdir):
             os.path.dirname(os.path.abspath(__file__)), "..", "titan", "settings"
         )
     ):
-        if "__" not in item and item != "base":
+        if "__" not in item and item != "base" and item != "philly-gis":  # bypass philly due to constraints
             path = tmpdir.mkdir(item)
             os.mkdir(os.path.join(path, "network"))
             print(f"-----------Starting run for {item}-----------")


### PR DESCRIPTION
Ignore philly on checking for stable pop because philly doesn't work with a small population
